### PR TITLE
Amp sign country names

### DIFF
--- a/CountryPicker/build.gradle.kts
+++ b/CountryPicker/build.gradle.kts
@@ -54,7 +54,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 groupId = "com.github.arpitkatiyar1999"
                 artifactId = "countrypicker"
-                version = "2.1.3"
+                version = "2.1.4"
                 from(components["release"])
             }
         }

--- a/CountryPicker/src/main/res/values/strings.xml
+++ b/CountryPicker/src/main/res/values/strings.xml
@@ -111,7 +111,7 @@
     <string name="us_virgin_islands">US Virgin Islands</string>
     <string name="british_virgin_islands">British Virgin Islands</string>
     <string name="venezuela_bolivarian_republic_of">Venezuela, Bolivarian Republic Of</string>
-    <string name="saint_vincent_amp_the_grenadines"><![CDATA[Saint Vincent &amp; The Grenadines]]></string>
+    <string name="saint_vincent_amp_the_grenadines">Saint Vincent &amp; The Grenadines</string>
     <string name="holy_see_vatican_city_state">Holy See (vatican City State)</string>
     <string name="uzbekistan">Uzbekistan</string>
     <string name="uruguay">Uruguay</string>
@@ -121,7 +121,7 @@
     <string name="tanzania_united_republic_of">Tanzania, United Republic Of</string>
     <string name="taiwan">Taiwan</string>
     <string name="tuvalu">Tuvalu</string>
-    <string name="trinidad_amp_tobago"><![CDATA[Trinidad &amp; Tobago]]></string>
+    <string name="trinidad_amp_tobago">Trinidad &amp; Tobago</string>
     <string name="turkey">Turkey</string>
     <string name="tonga">Tonga</string>
     <string name="tunisia">Tunisia</string>

--- a/app/src/main/java/com/arpitkatiyarprojects/countrypickerproject/ui/previews/CountryPickerPreviews.kt
+++ b/app/src/main/java/com/arpitkatiyarprojects/countrypickerproject/ui/previews/CountryPickerPreviews.kt
@@ -1,0 +1,35 @@
+package com.arpitkatiyarprojects.countrypickerproject.ui.previews
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.arpitkatiyarprojects.countrypicker.CountryPicker
+import com.arpitkatiyarprojects.countrypicker.models.SelectedCountryDisplayProperties
+import com.arpitkatiyarprojects.countrypicker.models.SelectedCountryProperties
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun CountryPickerPreview_FlagNames() {
+    MyPreview {
+        Column {
+            listOf(
+                "in",// Default
+                "tt",// Special characters
+                "vc",// Special characters & very long name
+                "sh",// Longest name
+            ).forEach { countryName ->
+                CountryPicker(
+                    selectedCountryDisplayProperties = SelectedCountryDisplayProperties(
+                        properties = SelectedCountryProperties(
+                            showCountryName = true,
+                        ),
+                    ),
+                    defaultCountryCode = countryName,
+                    onCountrySelected = {},
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arpitkatiyarprojects/countrypickerproject/ui/previews/PreviewHelper.kt
+++ b/app/src/main/java/com/arpitkatiyarprojects/countrypickerproject/ui/previews/PreviewHelper.kt
@@ -1,0 +1,29 @@
+package com.arpitkatiyarprojects.countrypickerproject.ui.previews
+
+import android.content.res.Configuration
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.arpitkatiyarprojects.countrypickerproject.ui.theme.CountryPickerProjectTheme
+
+/** Apply theme and background- / contentColor to the content of every Preview which uses this composable */
+@Composable
+fun MyPreview(
+    content: @Composable () -> Unit,
+) {
+    CountryPickerProjectTheme {
+        Surface {
+            content()
+        }
+    }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun MyPreviewPreview() {
+    MyPreview {
+        Text("Hello world!")
+    }
+}


### PR DESCRIPTION
Closes #19 

Fixes issues with country names which contain the `&` sign.

Also added a preview for demonstration purposes.